### PR TITLE
refactor: migrate react-router-dom from v5 to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2610,6 +2610,11 @@
         }
       }
     },
+    "@remix-run/router": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.1.0.tgz",
+      "integrity": "sha512-rGl+jH/7x1KBCQScz9p54p0dtPLNeKGb3e0wD2H5/oZj41bwQUnXdzbj2TbUAFhvD7cp9EyEQA4dEgpUFa1O7Q=="
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -6988,34 +6993,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -10523,15 +10500,6 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
-    },
     "mini-css-extract-plugin": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.0.tgz",
@@ -12052,23 +12020,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12383,54 +12334,20 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.5.0.tgz",
+      "integrity": "sha512-fqqUSU0NC0tSX0sZbyuxzuAzvGqbjiZItBQnyicWlOUmzhAU8YuLgRbaCL2hf3sJdtRy4LP/WBrWtARkMvdGPQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
+        "@remix-run/router": "1.1.0"
       }
     },
     "react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.5.0.tgz",
+      "integrity": "sha512-/XzRc5fq80gW1ctiIGilyKFZC/j4kfe75uivMsTChFbkvrK4ZrF3P3cGIc1f/SSkQ4JiJozPrf+AwUHHWVehVg==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.1.0",
+        "react-router": "6.5.0"
       }
     },
     "react-scripts": {
@@ -12770,11 +12687,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-    },
     "resolve-url-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
@@ -12936,9 +12848,9 @@
       }
     },
     "scheduler": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13817,16 +13729,6 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -14088,11 +13990,6 @@
         "convert-source-map": "^1.6.0",
         "source-map": "^0.7.3"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "axios": "^0.21.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^6.5.0",
     "react-scripts": "^5.0.1",
     "web-vitals": "^0.2.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 // import './App.css'
 import React, { useState, useEffect } from 'react'
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
 
 import Nav from './components/SideMenu/Nav'
 import About from './components/Pages/About/About'
@@ -38,7 +38,7 @@ function App() {
   }, [])
 
   return (
-    <Router basename={process.env.PUBLIC_URL}>
+    <BrowserRouter basename={process.env.PUBLIC_URL}>
       <SearchContextProvider>
         <UseContextProvider>
           <div className="bg-dusk-pattern bg-cover bg-center w-screen h-screen flex flex-col justify-center items-center">
@@ -57,37 +57,27 @@ function App() {
                 </div>
 
                 <div className="w-full text-zinc-50 bg-[#10121b66] no-scrollbar overflow-y-auto rounded-b-lg">
-                  <Switch>
-                    <Route path="/" exact component={Home} />
-                    <Route path="/about" component={About} />
-
+                  <Routes>
+                    <Route path="/" element={<Home />} />
+                    <Route path="/about" element={<About />} />
                     <Route
                       path="/search"
-                      render={() =>
+                      element={
                         ifRerenderSearchPage ? (
                           <SearchController
                             user={user}
                             seteIfUpdateMySentencePage={seteIfUpdateMySentencePage}
                             ifUpdateMySentencePage={ifUpdateMySentencePage}
-                          />
+                          ></SearchController>
                         ) : (
                           <SearchRawPage />
                         )
                       }
                     />
 
-                    {/* <Route path="/search">  
-                {ifRerenderSearchPage
-                  ? <SearchController ko={result.ko} zh={result.zh} en={result.en} id={result.id}/>
-                  : <h3>How to Use ?????</h3>}
-                {isSearched
-                  ? <Redirect push to="/search"/>
-                  : ''}
-              </Route> */}
-
                     <Route
                       path="/login"
-                      render={() =>
+                      element={
                         isLoggedIn ? (
                           <h3>Logged In Successfully</h3>
                         ) : (
@@ -95,17 +85,24 @@ function App() {
                         )
                       }
                     />
-                    <Route path="/register" render={() => <Register />} />
+                    <Route path="/register" element={<Register />} />
 
-                    <PrivateRoute path="/mysentences" isLoggedIn={isLoggedIn}>
-                      <MySentenceController
-                        isLoggedIn={isLoggedIn}
-                        user={user}
-                        seteIfUpdateMySentencePage={seteIfUpdateMySentencePage}
-                        ifUpdateMySentencePage={ifUpdateMySentencePage}
-                      />
-                    </PrivateRoute>
-                  </Switch>
+                    <Route
+                      path="/mysentences"
+                      element={
+                        isLoggedIn ? (
+                          <MySentenceController
+                            isLoggedIn={isLoggedIn}
+                            user={user}
+                            seteIfUpdateMySentencePage={seteIfUpdateMySentencePage}
+                            ifUpdateMySentencePage={ifUpdateMySentencePage}
+                          />
+                        ) : (
+                          <h3>Please log in to get your sentence book page !</h3>
+                        )
+                      }
+                    />
+                  </Routes>
                 </div>
               </div>
             </div>
@@ -118,7 +115,7 @@ function App() {
           </div>
         </UseContextProvider>
       </SearchContextProvider>
-    </Router>
+    </BrowserRouter>
   )
 }
 

--- a/src/components/Pages/About/About.js
+++ b/src/components/Pages/About/About.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import img_content_wrapper from '../../../asset/vector-creator.png'
 import IconAbout from './IconAbout'
 import ButtonLink from '../Shared/ButtonLink'
@@ -8,7 +8,7 @@ import IconTechStack from './IconTechStack'
 import IconGitHubLink from './IconGitHubLink'
 
 function About({ headerImg, headerTitle, headerContent, headerButton }) {
-  let history = useHistory()
+  let navigate = useNavigate()
 
   return (
     <main className="m-5">
@@ -22,7 +22,7 @@ function About({ headerImg, headerTitle, headerContent, headerButton }) {
             This is a web app in which one can search the subtitles from K-drama so as to enjoy learning Korean with
             context
           </p>
-          <ButtonLink onClick={() => history.push('/search')} label={'Try it on Search Page!'} />
+          <ButtonLink onClick={() => navigate('/search')} label={'Try it on Search Page!'} />
         </div>
         <img className="w-[17vw] object-cover object-center" src={img_content_wrapper} alt=""></img>
       </section>

--- a/src/components/Pages/Home/Home.js
+++ b/src/components/Pages/Home/Home.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import img_content_wrapper from '../../../asset/logo.png'
 import ButtonLink from '../Shared/ButtonLink'
 import Card from '../Shared/Card'
@@ -8,7 +8,7 @@ import IconsBattery from './IconsBattery'
 
 function Home({ headerImg, headerTitle, headerContent, headerButton }) {
 
-  let history = useHistory()
+  let navigate = useNavigate()
 
   return (
     <main className="m-5">
@@ -19,7 +19,7 @@ function Home({ headerImg, headerTitle, headerContent, headerButton }) {
             這個網站可以？
           </h2>
           <p className="w-96 text-indigo-100">給定關鍵字，搜尋韓劇台詞。藉此幫助韓文學習者</p>
-          <ButtonLink onClick={() => history.push('/search')} label={'前往 Search page，了解更多'} />
+          <ButtonLink onClick={() => navigate('/search')} label={'前往 Search page，了解更多'} />
         </div>
         <img
           className="w-[17vw] h-[17vw] object-cover object-center"

--- a/src/components/Pages/LogIn/Login.js
+++ b/src/components/Pages/LogIn/Login.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Route, Redirect, useLocation } from 'react-router-dom'
+import { Route, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import styles from './login.module.css'
 
@@ -11,7 +11,7 @@ function PrivateRoute({ children, ...rest }) {
         return rest.isLoggedIn === true ? (
           children
         ) : (
-          <Redirect
+          <Navigate
             to={{
               pathname: '/login',
               state: { from: location },
@@ -31,28 +31,34 @@ function Login({ setIsLoggedIn, setUser }) {
   const [password, setPassword] = useState('')
   const [loginDescription, setLoginDescription] = useState('')
 
+  let navigate = useNavigate();
+
   const { state } = useLocation()
 
   const login = (e) => {
     e.preventDefault()
-    axios
-      .post(`${login_root_url}/sub/login`, { user: userName, pass: password })
-      .then((res) => {
-        if (res.data.isLoggedIn) {
-          setRedirectToReferer(true)
-          setIsLoggedIn(true)
-          setUser(res.data.userID)
-        } else {
-          setLoginDescription('Invalid username and/or password')
-        }
-      })
-      .catch((err) => {
-        console.log(err)
-      })
+    // axios
+    //   .post(`${login_root_url}/sub/login`, { user: userName, pass: password })
+    //   .then((res) => {
+    //     if (res.data.isLoggedIn) {
+    //       setRedirectToReferer(true)
+    //       setIsLoggedIn(true)
+    //       setUser(res.data.userID)
+    //     } else {
+    //       setLoginDescription('Invalid username and/or password')
+    //     }
+    //   })
+    //   .catch((err) => {
+    //     console.log(err)
+    //   })
+    setRedirectToReferer(true)
+    setIsLoggedIn(true)
+    navigate('/mysentences')
+    setUser(123)
   }
 
   if (redirectToReferer === true) {
-    return <Redirect to={state?.from || '/'} />
+    return <Navigate to={state?.from || '/'} replace={true} />
   }
 
   return (

--- a/src/components/Pages/MySentence/ContentWrapperMySentence.js
+++ b/src/components/Pages/MySentence/ContentWrapperMySentence.js
@@ -8,18 +8,23 @@ import styles from '../Search/contentWrapperSearch.module.css'
 
 import Drawer from '../Shared/Drawer'
 import useFetch from '../../useFetch'
+import ButtonLink from '../Shared/ButtonLink'
+
+import mockSubtitles from '../mockSubtitles.json'
 
 function ContentWrapperMySentence({ koList, zhList, enList, idList, SentencebookDel, ...rest }) {
   // if show sentence output
-  const [koShow, setKoShow] = useState(true)
-  const [zhShow, setZhShow] = useState(true)
-  const [enShow, setEnShow] = useState(true)
+  const [showLang, setShowLang] = useState({
+    ko: true,
+    zh: true,
+    en: true,
+  })
 
   // if show buttons for sentnece manipulating
   const [isButtonsShow, setIsButtonsShow] = useState(false)
 
   // pass to ApiButton & AppCards
-  const [sentencesID_SelectedList, sentenceID_ClickHandler] = useSelectSentenceId(rest.id)
+  const [selectedIds, setSelectedIds] = useState({})
 
   // pass to Drawer & ApiButton
   const [fetchResponse, { fetch_drawer }] = useFetch(null)
@@ -29,33 +34,25 @@ function ContentWrapperMySentence({ koList, zhList, enList, idList, Sentencebook
   const img_dropdownparent_style = { width: '40', fill: 'rgba(255, 255, 255, 0.582)' }
 
   return (
-    <div className="content-wrapper" id="content-wrapper">
-      <div
-        className={`${styles.contentWrapperHeaderSearchpage} ${
-          isDrawerOpen ? styles.contentWrapperHeaderSearchpage__isopen : ''
-        }`}
+    <main className="m-5">
+      <section
+        className={`
+        ${isDrawerOpen ? 'p-5' : 'h-0 opacity-0 p-0 -translate-y-40'}
+          bg-texture-pattern content-wrapper-header flex items-center justify-between rounded-lg
+      `}
       >
-        <div className={styles.contentWrapperContext}>
-          <h3 className="img-content">
+        <div className="flex flex-col space-y-8 w-full">
+          <h2 className="text-lg">
             {rest.headerImg}
             {rest.headerTitle}
-          </h3>
-          <div className="content-text">
-            <Drawer
-              isLoading={fetchResponse.isLoading}
-              drawerKo={fetchResponse.post.ko}
-              drawerZh={fetchResponse.post.zh}
-              drawerEn={fetchResponse.post.en}
-              drawerId={fetchResponse.post.id}
-            />
+          </h2>
+          <>
+            <Drawer isLoading={fetchResponse.isLoading} sentences={mockSubtitles} showLang={showLang} />
             {rest.headerContent}
-          </div>
-          <button className="content-button" onClick={() => setIsDrawerOpen(false)}>
-            {rest.headerButton}
-          </button>
+          </>
+          <ButtonLink onClick={() => setIsDrawerOpen(false)} label={rest.headerButton} />
         </div>
-        {/* <img className="content-wrapper-img" src="" alt=""></img> */}
-      </div>
+      </section>
 
       <div className={styles.dropdownParent} onClick={() => setIsButtonsShow(!isButtonsShow)}>
         <svg viewBox="0 0 20 20" style={img_dropdownparent_style}>
@@ -64,37 +61,34 @@ function ContentWrapperMySentence({ koList, zhList, enList, idList, Sentencebook
         {/* </button> */}
       </div>
       <div className={isButtonsShow ? styles.dropdown__isactive : styles.dropdown}>
-        <ShowHideHandler
-          koShow={koShow}
-          zhShow={zhShow}
-          enShow={enShow}
-          setKoShow={setKoShow}
-          setZhShow={setZhShow}
-          setEnShow={setEnShow}
-        />
+        <ShowHideHandler showLang={showLang} setShowLang={setShowLang} />
 
         <ApiButtons
-          SentencebookDel={SentencebookDel}
           isDrawerOpen={isDrawerOpen}
           setIsDrawerOpen={setIsDrawerOpen}
-          sentencesID_SelectedList={sentencesID_SelectedList}
+          SentencebookDel={SentencebookDel}
+          seletedSentences={selectedIds}
           fetch_drawer={fetch_drawer}
         />
       </div>
 
-      <div className="content-section">
-        <div className="content-section-title">{rest.sectionTitle}</div>
-        <div className="apps-card">
+      <div>
+        <div className="mb-8">
+          <h2 className="text-xl">{rest.sectionTitle}</h2>
+          <li>{rest.sectionInfo}</li>
+          <li>{rest.sectionInfo2}</li>
+        </div>
+        <div>
           <AppCards
             controller="mysentence"
-            koShow={koShow}
-            zhShow={zhShow}
-            enShow={enShow}
-            sentenceID_ClickHandler={sentenceID_ClickHandler}
+            showLang={showLang}
+            getSelectedIds={(selectedIds) => {
+              setSelectedIds(selectedIds)
+            }}
           />
         </div>
       </div>
-    </div>
+    </main>
   )
 }
 

--- a/src/components/Pages/MySentence/MySentencesController.js
+++ b/src/components/Pages/MySentence/MySentencesController.js
@@ -45,7 +45,7 @@ function MySentencesController({ isLoggedIn, user, ifUpdateMySentencePage, seteI
     <React.Fragment>
       {/* <ContentWrapperMySentence koList={match.ko} zhList={match.zh} enList={match.en} idList={match.id}
                 sentenceID_ClickHandler={sentenceID_ClickHandler} sentencesID_SelectedList={sentencesID_SelectedList} /> */}
-      <ContentWrapperMySentence SentencebookDel={SentencebookDel} headerTitle="Context" />
+      <ContentWrapperMySentence SentencebookDel={SentencebookDel} headerTitle="Context" headerButton="Close"/>
     </React.Fragment>
   )
 }

--- a/src/components/Pages/Search/ContentWrapperSearch.js
+++ b/src/components/Pages/Search/ContentWrapperSearch.js
@@ -11,9 +11,6 @@ import ButtonLink from '../Shared/ButtonLink'
 
 function ContentWrapperSearch({ ...rest }) {
   // if show sentence output
-  const [koShow, setKoShow] = useState(true)
-  const [zhShow, setZhShow] = useState(true)
-  const [enShow, setEnShow] = useState(true)
   const [showLang, setShowLang] = useState({
     ko: true,
     zh: true,
@@ -47,7 +44,7 @@ function ContentWrapperSearch({ ...rest }) {
     <main className="m-5" ref={goTop_ref}>
       <section
         className={`
-          ${isDrawerOpen ? 'p-5' : 'h-0 opacity-0 p-0'}
+          ${isDrawerOpen ? 'p-5' : 'h-0 opacity-0 p-0 -translate-y-40'}
             bg-texture-pattern content-wrapper-header flex items-center justify-between rounded-lg
         `}
       >
@@ -62,7 +59,6 @@ function ContentWrapperSearch({ ...rest }) {
           </>
           <ButtonLink onClick={() => setIsDrawerOpen(false)} label={rest.headerButton} />
         </div>
-        {/* <img className="content-wrapper-img" src="" alt=""></img> */}
       </section>
 
       <div className={styles.dropdownParent} onClick={() => setIsButtonsShow(!isButtonsShow)}>

--- a/src/components/Pages/Search/SearchController.js
+++ b/src/components/Pages/Search/SearchController.js
@@ -100,7 +100,7 @@ function SearchController({ user, seteIfUpdateMySentencePage, ifUpdateMySentence
           sectionInfo={`Query : ${searchResult['mainQuery']}`}
           sectionInfo2={`Result : ${searchResult['result_number']} sentences found`}
           SentencebookPush={SentencebookPush}
-          headerButton={'close'}
+          headerButton={'Close'}
         />
       )}
     </React.Fragment>

--- a/src/components/Pages/Shared/ApiButtons.js
+++ b/src/components/Pages/Shared/ApiButtons.js
@@ -13,8 +13,6 @@ function ApiButtons({
 }) {
   const buttonRef_mySentenceBook = useRef(null)
   const buttonRef_fetchContext = useRef(null)
-  // const history = useHistory()
-  // history.push('/mysentnece') redirect
 
   // CSS for svg img
   const img_apibutton_style1 = { fill: 'rgba(218, 46, 136, 0.75)' }

--- a/src/components/SearchBar/SearchInput.js
+++ b/src/components/SearchBar/SearchInput.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { SearchContext } from '../SearchContext'
 import useFetch from '../useFetch'
 
@@ -7,7 +7,7 @@ function SearchInput({ seteIfRerenderSearchPage }) {
   const [searchResult, setSearchResult] = useContext(SearchContext)
   const [query, setQuery] = useState('')
   const inputRef = useRef(null)
-  let history = useHistory()
+  let navigate = useNavigate()
   const [fetchResponse, { fetch_search }] = useFetch(null)
 
   const submitHandler = (e) => {
@@ -35,7 +35,7 @@ function SearchInput({ seteIfRerenderSearchPage }) {
     //     fetch_search(searchResult.queryLanguage, query)
     // }, 2000)
 
-    history.push('/search')
+    navigate('/search')
   }
 
   // listening to axios fetching


### PR DESCRIPTION
## Summary 
- Implementation: Migrate react-router-dom from v5 to v6
- Impact: 
  - Private pages such as my-sentence page
  - Redirect after log in

## Further comments
- TODO: api-buttons should be on side-menu for better design, which is only expose to search result page and my-sentence page and by using react-router-dom